### PR TITLE
Tidy up, minor fixes, re-introduce pytest tests

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,6 +22,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
           pip install -r requirements.txt
+          # For now always install pytest, needed e.g. by pylint when browsing though pytest dir
+          pip install pytest
       - name: Test with ${{ matrix.test-tool }}
         run: |
           pip install ${{ matrix.test-tool }}
@@ -47,6 +49,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
           pip install -r requirements.txt
+          # For now always install pytest, needed e.g. by pylint when browsing though pytest dir
+          pip install pytest
       - name: Test with ${{ matrix.test-tool }}
         run: |
           pip install ${{ matrix.test-tool }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ env
 __pycache__
 .pytest_cache
 build
+**/o2tuner_pytest_workdir/

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,8 +11,8 @@ attr-naming-style=snake_case
 class-naming-style=PascalCase
 good-names=ax, df, i, j, k, x, y, z
 
-[MESSAGES CONTROL]
-disable=useless-object-inheritance,missing-function-docstring,too-many-branches
+# [MESSAGES CONTROL]
+# disable=useless-object-inheritance,missing-function-docstring,too-many-branches
 
 [DESIGN]
 max-args=10

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ matplotlib >= 3.5.1
 psutil >= 5.9.0
 seaborn >= 0.11.2
 pandas >= 1.4.2
+scikit-learn >= 1.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,4 +25,4 @@ where = src
 
 [flake8]
 max-line-length = 150
-extend-ignore = C901
+#extend-ignore = C901

--- a/src/o2tuner/__init__.py
+++ b/src/o2tuner/__init__.py
@@ -14,6 +14,9 @@ LOG = Log()
 
 
 def entrypoint():
+    """
+    Global entrypoint to O2Tuner
+    """
     arg_parser = O2TunerArgumentParser()
     # arg_parser.gen_config_help(O2Tuner.get_default_conf())
     args = arg_parser.parse_args()
@@ -28,6 +31,9 @@ def entrypoint():
 
 
 def process_actions(args):
+    """
+    Steer the chosen action to be executed
+    """
     if args.version:
         ver = str(require(__package__)[0].version)
         if ver == "LAST-TAG":
@@ -42,5 +48,8 @@ def process_actions(args):
 
 
 def process_run(args):
+    """
+    Forward arguments to the central run function
+    """
     if args.action == "run":
         run(args)

--- a/src/o2tuner/config.py
+++ b/src/o2tuner/config.py
@@ -31,14 +31,23 @@ CONFIG_STAGES_KEYS = [CONFIG_STAGES_USER_KEY, CONFIG_STAGES_OPTIMISATION_KEY, CO
 
 
 def get_work_dir():
+    """
+    Simply return the parent workdir
+    """
     return WORK_DIR.path
 
 
 def resolve_path(rel_cwd):
+    """
+    Resolve a relative path to find it inside the current parent workdir
+    """
     return join(WORK_DIR.path, rel_cwd)
 
 
 def get_done_dir():
+    """
+    Get the directory where finished tasks are noted
+    """
     return join(WORK_DIR.path, "o2tuner_done")
 
 
@@ -53,9 +62,10 @@ class Configuration:
         self.script_dir = script_dir
         self.all_stages = None
         if not self.setup():
+            # simply exit, the errors should have been printed by setup()
             sys.exit(1)
 
-    def setup(self):
+    def setup(self):  # noqa: C901 pylint: disable=too-many-branches
         """
         * Set working directories if not specified explicitly by the user
         * Several sanity checks of configuration
@@ -148,16 +158,25 @@ class Configuration:
 
     @staticmethod
     def set_work_dir(work_dir):
+        """
+        Set the current parent workdir
+        """
         WORK_DIR.path = abspath(work_dir)
 
     @staticmethod
     def prepare_work_dir():
+        """
+        Create current workdir structure
+        """
         make_dir(WORK_DIR.path)
         o2tuner_done_dir = get_done_dir()
         make_dir(o2tuner_done_dir)
 
     @staticmethod
     def get_stages_done():
+        """
+        Get list of stages that have been done already
+        """
         done_dir = get_done_dir()
         done_files = glob(f"{done_dir}/DONE_*")
         done = []
@@ -171,6 +190,9 @@ class Configuration:
 
     @staticmethod
     def set_stage_done(name, rel_cwd):
+        """
+        Mark a stage as done
+        """
         done_dir = get_done_dir()
         done_file = join(done_dir, f"DONE_{name}")
         with open(done_file, "w", encoding="utf-8") as done:

--- a/src/o2tuner/io.py
+++ b/src/o2tuner/io.py
@@ -14,7 +14,8 @@ LOG = Log()
 
 
 def exists_file(path):
-    """wrapper around python's os.path.isfile
+    """
+    Wrapper around python's os.path.isfile
 
     this has the possibility to add additional functionality if needed
     """
@@ -22,7 +23,8 @@ def exists_file(path):
 
 
 def exists_dir(path):
-    """wrapper around python's os.path.isdir
+    """
+    Wrapper around python's os.path.isdir
 
     this has the possibility to add additional functionality if needed
     """
@@ -30,23 +32,20 @@ def exists_dir(path):
 
 
 def make_dir(path):
-    """create a directory
+    """
+    Create a directory
     """
     if exists(path):
         if exists_file(path):
-            # if it exists and if that is actually a file instead of a directory, fail here...
+            # if it exists and if that is actually a file instead of a directory, abort here...
             LOG.error(f"Attempted to create directory {path}. However, a file seems to exist there, quitting")
             sys.exit(1)
             # ...otherwise just warn.
         LOG.warning(f"The directory {path} already exists, not overwriting")
         return
-    # make the whole path structure
     makedirs(path)
 
 
-########
-# YAML #
-########
 class NoAliasDumperYAML(yaml.SafeDumper):
     """
     Avoid refs in dumped YAML
@@ -58,7 +57,6 @@ class NoAliasDumperYAML(yaml.SafeDumper):
 def parse_yaml(path):
     """
     Wrap YAML reading
-    https://stackoverflow.com/questions/13518819/avoid-references-in-pyyaml
     """
     path = expanduser(path)
     try:
@@ -85,9 +83,6 @@ def dump_yaml(to_yaml, path, *, no_refs=False):
         sys.exit(1)
 
 
-########
-# JSON #
-########
 def parse_json(filepath):
     """
     Wrap JSON reading, needed for interfacing with O2 cut configuration files

--- a/src/o2tuner/log.py
+++ b/src/o2tuner/log.py
@@ -7,7 +7,7 @@ import sys
 import colorama
 
 
-class Log(object):
+class Log:
     """
     Logging class
     """
@@ -17,9 +17,15 @@ class Log(object):
         self.quiet = False
 
     def set_quiet(self, quiet=True):
+        """
+        En-/disable logging messages
+        """
         self.quiet = quiet
 
     def print_color(self, color_code, msg):
+        """
+        Implementation of logging
+        """
         if self.quiet:
             return
         sys.stderr.write(color_code)
@@ -29,13 +35,25 @@ class Log(object):
         sys.stderr.flush()
 
     def debug(self, msg):
+        """
+        Wrapper for debug messages
+        """
         self.print_color(colorama.Fore.MAGENTA, "[DEBUG]: " + msg)
 
     def info(self, msg):
+        """
+        Wrapper for info messages
+        """
         self.print_color(colorama.Fore.GREEN, "[INFO]: " + msg)
 
     def warning(self, msg):
+        """
+        Wrapper for warning messages
+        """
         self.print_color(colorama.Fore.YELLOW, "[WARNING]: " + msg)
 
     def error(self, msg):
+        """
+        Wrapper for error messages
+        """
         self.print_color(colorama.Fore.RED, "[ERROR]: " + msg)

--- a/src/o2tuner/optimise.py
+++ b/src/o2tuner/optimise.py
@@ -9,7 +9,7 @@ from multiprocessing import set_start_method as mp_set_start_method
 import functools
 
 from o2tuner.io import make_dir, parse_yaml
-from o2tuner.backends import OptunaHandler
+from o2tuner.backends import OptunaHandler, can_do_storage
 from o2tuner.sampler import construct_sampler
 from o2tuner.inspector import O2TunerInspector
 from o2tuner.log import Log
@@ -20,11 +20,11 @@ mp_set_start_method("fork")
 LOG = Log()
 
 
-def optimise_run(objective, optuna_storage_config, sampler_config, n_trials, work_dir, user_config, run_serial):
+def optimise_run(objective, optuna_storage_config, sampler_config, n_trials, work_dir, user_config, in_memory):
     """
     Run one of those per job
     """
-    handler = OptunaHandler(optuna_storage_config.get("name", None), optuna_storage_config.get("storage", None), work_dir, user_config, run_serial)
+    handler = OptunaHandler(optuna_storage_config.get("name", None), optuna_storage_config.get("storage", None), work_dir, user_config, in_memory)
     handler.set_objective(objective)
     handler.set_sampler(construct_sampler(sampler_config))
     handler.initialise(n_trials)
@@ -50,12 +50,15 @@ def optimise(objective, optuna_config, *, work_dir="o2tuner_optimise", user_conf
     # investigate storage properties
     optuna_storage_config = optuna_config.get("study", {})
 
-    run_serial = False
+    in_memory = False
     if not optuna_storage_config.get("name", None) or not optuna_storage_config.get("storage", None):
         # we reduce the number of jobs to 1. Either missing the table name or the storage path will anyway always lead to a new study
         LOG.info("No storage provided, running only one job.")
-        run_serial = True
+        in_memory = True
         jobs = 1
+
+    if "storage" in optuna_storage_config and not can_do_storage(optuna_storage_config["storage"]):
+        return False
 
     if trials < jobs:
         LOG.info(f"Attempt to do {trials} trials, hence reducing the number of jobs from {jobs} to {trials}")
@@ -63,8 +66,9 @@ def optimise(objective, optuna_config, *, work_dir="o2tuner_optimise", user_conf
 
     trials_list = floor(trials / jobs)
     trials_list = [trials_list] * jobs
-    # add the left-over trials simply to the last job for now
-    trials_list[-1] += trials - sum(trials_list)
+    # add the left-over trials as equally as possible
+    for i in range(trials - sum(trials_list)):
+        trials_list[i] += 1
 
     LOG.info(f"Number of jobs: {jobs}\nNumber of trials: {trials}")
 
@@ -73,7 +77,7 @@ def optimise(objective, optuna_config, *, work_dir="o2tuner_optimise", user_conf
     procs = []
     for trial in trials_list:
         procs.append(Process(target=optimise_run,
-                             args=(objective, optuna_storage_config, optuna_config.get("sampler", None), trial, work_dir, user_config, run_serial)))
+                             args=(objective, optuna_storage_config, optuna_config.get("sampler", None), trial, work_dir, user_config, in_memory)))
         procs[-1].start()
         sleep(5)
 
@@ -85,12 +89,15 @@ def optimise(objective, optuna_config, *, work_dir="o2tuner_optimise", user_conf
         sleep(10)
 
     insp = O2TunerInspector()
-    insp.load(optuna_config, work_dir, user_config)
+    insp.load(optuna_config, work_dir)
     insp.write_summary()
     return True
 
 
 def needs_cwd(func):
+    """
+    Decorator to be used for objective functions to indicate whether they need a dedicated directory to run in
+    """
     @functools.wraps(func)
     def decorator(*args, **kwargs):
         return func(*args, **kwargs)

--- a/src/o2tuner/run.py
+++ b/src/o2tuner/run.py
@@ -16,13 +16,19 @@ LOG = Log()
 
 
 def get_stage_work_dir(name, config):
+    """
+    Get the working directory name of a given stage by its name
+    """
     cwd_rel = config.get("cwd", name)
     return join(get_work_dir(), cwd_rel), cwd_rel
 
 
 def run_cmd_or_python(cwd, name, config):
+    """
+    Run a user python function from a given file or simply a command line
+    """
     if "python" in config:
-        # import function to be execuuted
+        # import function to be executed
         func = import_function_from_file(config["python"]["file"], config["python"]["entrypoint"])
         # cache current directory
         this_dir = getcwd()
@@ -73,7 +79,7 @@ def run_inspector(cwd, config, stages_optimisation):
         opt_config = stages_optimisation[optimisation]
         opt_cwd, _ = get_stage_work_dir(optimisation, opt_config)
         insp = O2TunerInspector()
-        if not insp.load(opt_config["optuna_config"], opt_cwd, config["config"]):
+        if not insp.load(opt_config["optuna_config"], opt_cwd):
             continue
         inspectors.append(insp)
 
@@ -90,7 +96,7 @@ def run_inspector(cwd, config, stages_optimisation):
     return ret
 
 
-def run_stages(config, which_stages):
+def run_stages(config, which_stages):  # noqa: C901
     """
     Run the stages defined in the config specified by the user
     Run all if nothing is specified

--- a/src/o2tuner/sampler.py
+++ b/src/o2tuner/sampler.py
@@ -9,6 +9,7 @@ from o2tuner.log import Log
 LOG = Log()
 
 
+# our current dictionary of sampler; eventually we might just support all of the ones available in optuna
 SAMPLERS = {"base": BaseSampler,
             "grid": GridSampler,
             "random": RandomSampler,
@@ -17,6 +18,9 @@ SAMPLERS = {"base": BaseSampler,
 
 
 def construct_sampler(sampler_config=None):
+    """
+    Construct a smapler from potential custom configuration
+    """
     if not sampler_config:
         return TPESampler()
     name = sampler_config.get("name").lower()

--- a/src/o2tuner/system.py
+++ b/src/o2tuner/system.py
@@ -25,15 +25,15 @@ def run_command(cmd, *, cwd="./", log_file=None, wait=True):
     if wait:
         proc.wait()
         if ret := proc.returncode:
-            # check the return code and exit if != 0
-            LOG.error("There seems to have been a problem with the process launched with {cmd}. Its exit code was {ret}.")
+            # check the return code and exit if != 0, if the user does not want to wait, they are responsible to handle potential errors
+            LOG.error(f"There seems to have been a problem with the process launched with {cmd}. Its exit code was {ret}.")
             sys.exit(ret)
     return proc, join(cwd, log_file)
 
 
 def load_file_as_module(path, module_name):
     """
-    load path as module
+    Load a given file as a module
     """
     lookup_key = abspath(path)
     if path in LOADED_MODULES:
@@ -51,6 +51,9 @@ def load_file_as_module(path, module_name):
 
 
 def import_function_from_module(module_name, function_name):
+    """
+    Wrapper to manually load a function from a module
+    """
     module = importlib.import_module(module_name)
     if not hasattr(module, function_name):
         LOG.error(f"Cannot find function {function_name} in module {module.__name__}")
@@ -59,6 +62,9 @@ def import_function_from_module(module_name, function_name):
 
 
 def import_function_from_file(path, function_name):
+    """
+    Manually load a function from a file
+    """
     path = abspath(path)
     module_name = load_file_as_module(path, path.replace("/", "_").replace(".", "_"))
     return import_function_from_module(module_name, function_name)

--- a/src/o2tuner/tuner.py
+++ b/src/o2tuner/tuner.py
@@ -3,9 +3,6 @@ O2Tuner module
 """
 
 
-import os
-import yaml
-from yaml import YAMLError
 from o2tuner.log import Log
 
 LOG = Log()
@@ -22,50 +19,3 @@ class O2TunerError(Exception):
 
     def __str__(self):
         return self.msg
-
-
-class O2Tuner(object):
-    """
-    Steering class for O2tuner
-    """
-
-    def __init__(self, handler) -> None:
-        self._handler = handler
-        self._conf = {}
-
-    @staticmethod
-    def get_default_conf():
-        return {"executable": "/bin/true"}
-
-    def parse_config(self):
-        """
-        Open configuration file and reset inner configuration
-        """
-        conf_file = os.path.join(os.path.expanduser("~"),
-                                 ".o2tuner-config.yaml")
-        try:
-            with open(conf_file, encoding="utf8") as conf_file_data:
-                conf_override = yaml.safe_load(conf_file_data)
-                for k in self._conf:
-                    self._conf[k] = conf_override.get(k, self._conf[k])
-        except (OSError, IOError, YAMLError, AttributeError):
-            pass
-
-    def override_config(self, override):
-        """
-        Override inner configuration with provided one if keys exists
-        """
-        if not override:
-            return
-        for k in self._conf:
-            if not override.get(k) is None:
-                self._conf[k] = override[k]
-
-    def reset_handler(self, handler):
-        self._handler = handler
-
-    def init(self, **kwargs):
-        self._handler.initialise(**kwargs)
-
-    def run(self):
-        self._handler.optimise()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+"""
+Global configuration for pytest
+"""
+
+from os import makedirs
+from os.path import exists, join
+import shutil
+import pytest
+
+# Make sure all tests are executed in another working directory
+# so we do not pollute the directory where the test is executed.
+
+
+@pytest.fixture(autouse=True)
+def test_workdir(request, monkeypatch):
+    """
+    Prepare a tests working directory and make sure it runs in there
+    """
+    work_dir = "o2tuner_pytest_workdir"
+    if not exists(work_dir):
+        makedirs(work_dir)
+
+    this_function_name = request.function.__name__
+    this_cwd = f"{request.fspath.basename}_{this_function_name}_dir"
+
+    this_cwd = join(work_dir, this_cwd)
+
+    if exists(this_cwd):
+        shutil.rmtree(this_cwd)
+    makedirs(this_cwd)
+    monkeypatch.chdir(this_cwd)
+
+
+@pytest.fixture
+def needs_sqlite():
+    """
+    Mark as to-be-skipped if sqlite3 is not present
+    """
+    try:
+        import sqlite3  # noqa: F401 pylint: disable=import-outside-toplevel,unused-import
+    except ImportError:
+        pytest.skip("no module sqlite3")

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -33,9 +33,8 @@ test-flake8() {
 
 test-pytest() {
     test-setup
-    perr "running test: pytest is now disabled"
     type pytest
-    # pytest -x tests
+    pytest -x tests -rfEsp -vv
 }
 
 test-all() {

--- a/tests/test_create_load_study.py
+++ b/tests/test_create_load_study.py
@@ -1,0 +1,40 @@
+"""
+Test creating and loading of study
+"""
+from os.path import exists
+
+import optuna
+
+from o2tuner.backends import load_or_create_study, can_do_storage, pickle_study
+
+
+def test_inmemory_creation_and_pickle():
+    """
+    Test in-memory creation of study and make sure it can be pickled
+    """
+    study_name = "o2tuner_test_study"
+    has_storage, study = load_or_create_study(study_name)
+    assert not has_storage
+    assert isinstance(study, optuna.study.Study)
+    assert study.study_name == study_name
+    filename = pickle_study(study, "./")
+    assert exists(filename)
+
+
+def test_storage_unknown():
+    """
+    Make sure it fails for unknown storage
+    """
+    storage = "xyz:///study"
+    assert not can_do_storage(storage)
+
+
+def test_storage_creation(needs_sqlite):  # pylint: disable=unused-argument
+    """
+    Test storage creation of study
+    """
+    study_name = "o2tuner_test_study"
+    storage = "sqlite:///o2tuner_test_study.db"
+    has_storage, study = load_or_create_study(study_name, storage)
+    assert has_storage
+    assert isinstance(study, optuna.study.Study)

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,3 +1,0 @@
-"""
-Module used to test if installation is successful
-"""

--- a/tests/test_optimisation.py
+++ b/tests/test_optimisation.py
@@ -1,0 +1,104 @@
+"""
+Test optimisation chain
+"""
+from os.path import exists
+
+from o2tuner.optimise import optimise
+from o2tuner.inspector import O2TunerInspector
+from o2tuner.utils import annotate_trial
+
+
+def objective(trial):
+    """
+    A dummy objective
+    """
+    x = trial.suggest_float("x", -10, 10)
+    y = trial.suggest_float("y", -10, 10)
+    annotate_trial(trial, "sum", x + y)
+    return (x - 2)**2 + (y - 3)**2
+
+
+def test_inmemory_optimisation():
+    """
+    Simple in-memory optimisation
+    """
+    study_name = "o2tuner_test_study"
+    optuna_config = {"study": {"name": study_name},
+                     "trials": 100}
+    assert optimise(objective, optuna_config, work_dir="./")
+    assert exists(f"{study_name}.pkl")
+
+
+def test_storage_optimisation(needs_sqlite):  # pylint: disable=unused-argument
+    """
+    Simple optimisation using SQLite storage
+    """
+    study_name = "o2tuner_test_study"
+    storage_filename = "test.db"
+    optuna_config = {"study": {"name": study_name, "storage": f"sqlite:///{storage_filename}"},
+                     "trials": 100,
+                     "jobs": 2}
+    assert optimise(objective, optuna_config, work_dir="./")
+    assert exists(storage_filename)
+
+
+def test_full_inmemory_optimisation():
+    """
+    Full optimisation and inspector chain in-memory
+    """
+    study_name = "o2tuner_test_study"
+    optuna_config = {"study": {"name": study_name},
+                     "trials": 100}
+    assert optimise(objective, optuna_config, work_dir="./")
+    # now resume
+    assert optimise(objective, optuna_config, work_dir="./")
+    assert exists(f"{study_name}.pkl")
+    # now load everything into an inspector
+    insp = O2TunerInspector()
+    insp.load(optuna_config, "./")
+    losses = insp.get_losses()
+    # should now have 200 trials
+    assert len(losses) == 200
+    # check annotations
+    annotations = insp.get_annotation_per_trial("sum")
+    assert len(annotations) == len(losses)
+    assert all(ann is not None for ann in annotations)
+    # plot everything we have
+    figure, axes = insp.plot_importance()           # pylint: disable=unused-variable
+    figure, axes = insp.plot_parallel_coordinates()
+    figure, axes = insp.plot_slices()
+    figure, axes = insp.plot_correlations()
+    figure, axes = insp.plot_pairwise_scatter()
+    figure, axes = insp.plot_loss_feature_history()
+
+
+def test_full_storage_optimisation(needs_sqlite):  # pylint: disable=unused-argument
+    """
+    Full optimisation and inspector chain using SQLite storage
+    """
+    study_name = "o2tuner_test_study"
+    storage_filename = "test.db"
+    optuna_config = {"study": {"name": study_name, "storage": f"sqlite:///{storage_filename}"},
+                     "trials": 100,
+                     "jobs": 2}
+    assert optimise(objective, optuna_config, work_dir="./")
+    # now resume
+    assert optimise(objective, optuna_config, work_dir="./")
+    assert exists(storage_filename)
+    # now load everything into an inspector
+    insp = O2TunerInspector()
+    insp.load(optuna_config, "./")
+    losses = insp.get_losses()
+    # should now have 200 trials
+    assert len(losses) == 200
+    # check annotations
+    annotations = insp.get_annotation_per_trial("sum")
+    assert len(annotations) == len(losses)
+    assert all(ann is not None for ann in annotations)
+    # plot everything we have
+    figure, axes = insp.plot_importance()           # pylint: disable=unused-variable
+    figure, axes = insp.plot_parallel_coordinates()
+    figure, axes = insp.plot_slices()
+    figure, axes = insp.plot_correlations()
+    figure, axes = insp.plot_pairwise_scatter()
+    figure, axes = insp.plot_loss_feature_history()


### PR DESCRIPTION
* add basic doc strings everywhere

* enable all pylint and flake8 warnings again
  * only in tests (see more below) some warnings are explixitly disabled, since the way it is coded now is the way it has to be (not recognised by pylint or flake8)
  * for 2 functions, explicit disabling:
    * config.py: Config.setup()
    * run.py: run_stages() to be revised

Some of the most notable changes and fixes

* inpsector
  * consolidate extraction of most important parameters
  * remove some code duplications
  * put None for parameter values in trials where parameter was not used instead of simply ignoreing the parameter in e.g. history plots

* backends.py
  * introduce a quick dryrun to find out if storage is supported used in optimise.py
  * better handling of storage (paths) and their ability to use them

* optimise.py
  * distribute trials more fairly to jobs

* tuner.py basically removed all unused code

* re-introduce tests
  * each test is run in a dedicated directory to not pollute the cwd with test artefacts
  * test basic functionality
  * test in-memory and SQLite based optimisations
  * full chain from optimisation to evaluation with inspector