### PR TITLE
Config, optimisation

### DIFF
--- a/src/o2tuner/backends.py
+++ b/src/o2tuner/backends.py
@@ -77,6 +77,13 @@ def adjust_storage_path(storage_path, workdir="./"):
     return check_prefix + join(workdir, path)
 
 
+def get_default_storage(study_name):
+    """
+    Construct a default storage path
+    """
+    return f"sqlite:///{study_name}.db"
+
+
 def load_or_create_study_from_storage(study_name, storage, sampler=None, create_if_not_exists=True):
     """
     Load or create from DB

--- a/tests/test_full/config_full.yaml
+++ b/tests/test_full/config_full.yaml
@@ -7,6 +7,7 @@ stages_optimisation:
   optimisation:
     config:
       some_key: some_value
+    cwd: optimisation_other
     file: optimise.py
     objective: objective
     jobs: 2     # desired number of jobs
@@ -14,5 +15,6 @@ stages_optimisation:
     study:      # where the study is stored (only give a name and leave out "storage" key if you do not have MySQL working, it will anyway fall back to the serial run if it cannot communicate with MySQL)
       name: "test_study"
       storage: sqlite:///opt.db
+      in_memory: False
     deps:
       - hello

--- a/tests/test_full/config_minimal.yaml
+++ b/tests/test_full/config_minimal.yaml
@@ -1,0 +1,13 @@
+stages_user:
+  hello:
+    cmd: "echo Hello"
+
+
+stages_optimisation:
+  optimisation:
+    config:
+      some_key: some_value
+    file: optimise.py
+    objective: objective
+    deps:
+      - hello

--- a/tests/test_full/test_entrypoint.py
+++ b/tests/test_full/test_entrypoint.py
@@ -4,21 +4,22 @@ Test optimisation chain
 from os.path import exists, join
 
 from o2tuner.run import run
+from o2tuner.bookkeeping import AttrHolder
 
 
-class AttrHolder:  # pylint: disable=(too-few-public-methods
+def test_entrypoint_full_config(needs_sqlite, test_source_dir):  # pylint: disable=unused-argument
     """
-    To emulate what is done from argparse
+    Simple optimisation using SQLite storage, use full optimisation config
     """
-    def __init__(self, **kwargs):
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+    config = join(test_source_dir, "config_full.yaml")
+    assert exists(config)
+    assert run(AttrHolder(config=config, work_dir="./", script_dir=None, stages=None)) == 0
 
 
-def test_entrypoint(needs_sqlite, test_source_dir):  # pylint: disable=unused-argument
+def test_entrypoint_minimal_config(needs_sqlite, test_source_dir):  # pylint: disable=unused-argument
     """
-    Simple optimisation using SQLite storage
+    Simple optimisation using SQLite storage, use minimal optimisation
     """
-    config = join(test_source_dir, "config.yaml")
+    config = join(test_source_dir, "config_minimal.yaml")
     assert exists(config)
     assert run(AttrHolder(config=config, work_dir="./", script_dir=None, stages=None)) == 0

--- a/tests/test_optimisation.py
+++ b/tests/test_optimisation.py
@@ -23,7 +23,7 @@ def test_inmemory_optimisation():
     Simple in-memory optimisation
     """
     study_name = "o2tuner_test_study"
-    optuna_config = {"study": {"name": study_name},
+    optuna_config = {"study": {"name": study_name, "in_memory": True},
                      "trials": 100}
     assert optimise(objective, optuna_config, work_dir="./")
     assert exists(f"{study_name}.pkl")
@@ -47,7 +47,7 @@ def test_full_inmemory_optimisation():
     Full optimisation and inspector chain in-memory
     """
     study_name = "o2tuner_test_study"
-    optuna_config = {"study": {"name": study_name},
+    optuna_config = {"study": {"name": study_name, "in_memory": True},
                      "trials": 100}
     assert optimise(objective, optuna_config, work_dir="./")
     # now resume


### PR DESCRIPTION
* always prefer optimisation via storage, unless
  * "in_memory" is set explicitly OR
  * "jobs" is set to one and optimisation via storage was found to not be possible

* allow for more minimal optimisation configuration

* disentangle setup of opt, eval and user stages