### PR TITLE
Add timeout for DB access and sanitize

### DIFF
--- a/src/o2tuner/optimise.py
+++ b/src/o2tuner/optimise.py
@@ -9,7 +9,7 @@ from multiprocessing import set_start_method as mp_set_start_method
 import functools
 
 from o2tuner.io import make_dir, parse_yaml
-from o2tuner.backends import OptunaHandler, can_do_storage, get_default_storage
+from o2tuner.backends import OptunaHandler, can_do_storage, get_default_storage_url
 from o2tuner.sampler import construct_sampler
 from o2tuner.inspector import O2TunerInspector
 from o2tuner.exception import O2TunerStopOptimisation
@@ -81,13 +81,13 @@ def prepare_optimisation(optuna_config, work_dir="o2tuner_optimise"):
 
     if not storage and not in_memory:
         # make a default storage, optimisation via storage should be the way to go
-        storage = get_default_storage(study_name)
+        storage = get_default_storage_url(study_name)
 
     if not in_memory and not can_do_storage(storage):
         # no worries - at this point - if optimisation via storage is not possible
         optuna_storage_config["storage"] = None
         if jobs > 1:
-            # however, if more than 1 one requested, abort the preparation here
+            # however, if more than 1 job requested, abort the preparation here
             LOG.error("Requested %d jobs but problem to set up storage %s", jobs, storage)
             return None, None, None
     else:


### PR DESCRIPTION
* rework the way of testing whether optimisation can be done using DB (previously was somewhat tailored to SQLite but of course it should work e.g. for MySQL just as well)

* by default, add 100s timeout for DB access, otherwise it can happen that even for a low number of parallel jobs, the optimisation fails due to locked DB

* possibility to pass kwargs in config to be used when cretaing the storage